### PR TITLE
feat: Implement conversation session management

### DIFF
--- a/db/create_schema.sql
+++ b/db/create_schema.sql
@@ -50,6 +50,7 @@ CREATE TABLE audio_features (
 -- =======================================
 CREATE TABLE conversation_history (
     id INT IDENTITY(1,1) PRIMARY KEY,
+    session_id TEXT NOT NULL, -- Added this line
     timestamp DATETIME DEFAULT GETDATE(),
     user_prompt NVARCHAR(MAX) NOT NULL,
     ai_response NVARCHAR(MAX) NOT NULL

--- a/db/history_operations.py
+++ b/db/history_operations.py
@@ -1,14 +1,19 @@
 import pyodbc
 from db.connection import get_connection
+import uuid
 
-def save_conversation(user_prompt: str, ai_response: str):
+def generate_session_id() -> str:
+    """Generates a unique session ID."""
+    return str(uuid.uuid4())
+
+def save_conversation(user_prompt: str, ai_response: str, session_id: str):
     """Saves a conversation to the database."""
     try:
         conn = get_connection()
         if conn:
             cursor = conn.cursor()
-            sql = "INSERT INTO conversation_history (user_prompt, ai_response) VALUES (?, ?)"
-            cursor.execute(sql, user_prompt, ai_response)
+            sql = "INSERT INTO conversation_history (user_prompt, ai_response, session_id) VALUES (?, ?, ?)"
+            cursor.execute(sql, user_prompt, ai_response, session_id)
             conn.commit()
             print("✅ Conversation saved successfully.")
             cursor.close()
@@ -23,18 +28,61 @@ def save_conversation(user_prompt: str, ai_response: str):
         print(f"❌ An unexpected error occurred while saving conversation: {e}")
 
 def get_all_conversations() -> list:
-    """Retrieves all conversations from the database, ordered by timestamp descending."""
-    conversations = []
+    """Retrieves all unique conversation sessions from the database, showing the first prompt of each."""
+    sessions = []
     try:
         conn = get_connection()
         if conn:
             cursor = conn.cursor()
-            # Order by ID descending as it's an IDENTITY column, which implies order of insertion
-            sql = "SELECT id, timestamp, user_prompt, ai_response FROM conversation_history ORDER BY id DESC"
+            sql = """
+            WITH RankedConversations AS (
+                SELECT
+                    session_id,
+                    user_prompt,
+                    timestamp,
+                    ROW_NUMBER() OVER(PARTITION BY session_id ORDER BY id ASC) as rn
+                FROM conversation_history
+            )
+            SELECT
+                session_id,
+                user_prompt,
+                timestamp
+            FROM RankedConversations
+            WHERE rn = 1
+            ORDER BY timestamp DESC;
+            """
             cursor.execute(sql)
             rows = cursor.fetchall()
             for row in rows:
-                conversations.append({
+                sessions.append({
+                    "session_id": row.session_id,
+                    "first_user_prompt": row.user_prompt,
+                    "timestamp": row.timestamp
+                })
+            cursor.close()
+            conn.close()
+        else:
+            print("⚠️ Could not connect to the database to retrieve conversation sessions.")
+    except pyodbc.Error as ex:
+        sqlstate = ex.args[0]
+        print(f"❌ Error retrieving conversation sessions: {sqlstate}")
+        print(ex)
+    except Exception as e:
+        print(f"❌ An unexpected error occurred while retrieving conversation sessions: {e}")
+    return sessions
+
+def get_conversation_by_session_id(session_id: str) -> list:
+    """Retrieves all turns for a specific conversation session ID, ordered by timestamp."""
+    conversation_turns = []
+    try:
+        conn = get_connection()
+        if conn:
+            cursor = conn.cursor()
+            sql = "SELECT id, timestamp, user_prompt, ai_response FROM conversation_history WHERE session_id = ? ORDER BY id ASC"
+            cursor.execute(sql, session_id)
+            rows = cursor.fetchall()
+            for row in rows:
+                conversation_turns.append({
                     "id": row.id,
                     "timestamp": row.timestamp,
                     "user_prompt": row.user_prompt,
@@ -43,40 +91,11 @@ def get_all_conversations() -> list:
             cursor.close()
             conn.close()
         else:
-            print("⚠️ Could not connect to the database to retrieve conversations.")
+            print("⚠️ Could not connect to the database to retrieve conversation details.")
     except pyodbc.Error as ex:
         sqlstate = ex.args[0]
-        print(f"❌ Error retrieving conversations: {sqlstate}")
+        print(f"❌ Error retrieving conversation details by session ID: {sqlstate}")
         print(ex)
     except Exception as e:
-        print(f"❌ An unexpected error occurred while retrieving conversations: {e}")
-    return conversations
-
-def get_conversation_by_id(conversation_id: int) -> dict | None:
-    """Retrieves a specific conversation by its ID."""
-    conversation = None
-    try:
-        conn = get_connection()
-        if conn:
-            cursor = conn.cursor()
-            sql = "SELECT id, timestamp, user_prompt, ai_response FROM conversation_history WHERE id = ?"
-            cursor.execute(sql, conversation_id)
-            row = cursor.fetchone()
-            if row:
-                conversation = {
-                    "id": row.id,
-                    "timestamp": row.timestamp,
-                    "user_prompt": row.user_prompt,
-                    "ai_response": row.ai_response
-                }
-            cursor.close()
-            conn.close()
-        else:
-            print("⚠️ Could not connect to the database to retrieve conversation.")
-    except pyodbc.Error as ex:
-        sqlstate = ex.args[0]
-        print(f"❌ Error retrieving conversation by ID: {sqlstate}")
-        print(ex)
-    except Exception as e:
-        print(f"❌ An unexpected error occurred while retrieving conversation by ID: {e}")
-    return conversation
+        print(f"❌ An unexpected error occurred while retrieving conversation details by session ID: {e}")
+    return conversation_turns

--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
 from gemini_model import call_gemini, generar_consulta_sql
-from db.history_operations import save_conversation, get_all_conversations, get_conversation_by_id
+from db.history_operations import save_conversation, get_all_conversations, get_conversation_by_session_id, generate_session_id
 
 # Variable global para controlar el estado de la conversación
 is_conversation_active = False
+current_session_id = None
 
 def display_menu():
     print("\n--- Menú Principal ---")
@@ -12,6 +13,7 @@ def display_menu():
 
 def start_new_chat():
     global is_conversation_active
+    global current_session_id
     if is_conversation_active:
         print("Ya hay una conversación en curso.")
         while True:
@@ -30,6 +32,8 @@ def start_new_chat():
 
     # Si llegamos aquí, no había conversación activa o el usuario eligió iniciar una nueva.
     is_conversation_active = True
+    current_session_id = generate_session_id()
+    # print(f"Nueva sesión de conversación iniciada: {current_session_id}") # Optional: for debugging/info
 
     print("\n--- Nuevo Chat con Gemini o Anthropic (Escribe 'salir' para terminar) ---\n")
     modelo = ""
@@ -54,7 +58,7 @@ def start_new_chat():
             estructura_tabla = ""  # Aquí deberías cargar la estructura de la tabla desde la base de datos
             respuesta = generar_consulta_sql(modelo, pregunta, estructura_tabla, PROMPT_GENERAR_SQL)
             print(f"\n🔍 Respuesta generada por {modelo.capitalize()}:\n{respuesta}\n")
-            save_conversation(pregunta, respuesta) 
+            save_conversation(pregunta, respuesta, current_session_id)
         except Exception as e:
             print(f"❌ Error al generar respuesta: {e}")
 
@@ -65,31 +69,36 @@ def view_history():
         print("No hay conversaciones en el historial.")
         return
 
-    for conv in conversations:
-        user_prompt_short = (conv['user_prompt'][:75] + '...') if len(conv['user_prompt']) > 75 else conv['user_prompt']
-        print(f"{conv['id']}. [{conv['timestamp'].strftime('%Y-%m-%d %H:%M:%S')}] Tú: {user_prompt_short}")
+    for conv_session in conversations: # conversations now holds session summaries
+        first_prompt_short = (conv_session['first_user_prompt'][:75] + '...') if len(conv_session['first_user_prompt']) > 75 else conv_session['first_user_prompt']
+        print(f"Sesión ID: {conv_session['session_id']} [{conv_session['timestamp'].strftime('%Y-%m-%d %H:%M:%S')}] Inicio: {first_prompt_short}")
 
     while True:
         try:
-            choice = input("Ingresa el ID de la conversación para ver detalles (o '0' para volver al menú): ")
-            if choice == '0':
+            session_id_choice = input("Ingresa el ID de la sesión para ver detalles (o '0' para volver al menú): ").strip() # Renamed choice for clarity
+            if session_id_choice == '0':
                 break
-            conv_id = int(choice)
-            selected_conv = next((c for c in conversations if c['id'] == conv_id), None)
 
-            if selected_conv:
-                print("\n--- Detalle de la Conversación ---")
-                print(f"ID: {selected_conv['id']}")
-                print(f"Fecha: {selected_conv['timestamp'].strftime('%Y-%m-%d %H:%M:%S')}")
-                print(f"Tú: {selected_conv['user_prompt']}")
-                print(f"Gemini: {selected_conv['ai_response']}")
-                print("------------------------------------\n")
+            # Validate if the chosen session_id exists in the list of displayed sessions
+            # conversations is the list from get_all_conversations()
+            is_valid_session_id = any(cs['session_id'] == session_id_choice for cs in conversations)
+
+            if is_valid_session_id:
+                print("\n--- Detalle de la Conversación (Sesión ID: " + session_id_choice + ") ---")
+                detailed_turns = get_conversation_by_session_id(session_id_choice)
+                if not detailed_turns:
+                    # This case should ideally be rare if is_valid_session_id check is done from the current list
+                    print(f"No se encontraron turnos para la sesión ID: {session_id_choice}")
+                for turn in detailed_turns:
+                    print(f"  ID Turno: {turn['id']} [{turn['timestamp'].strftime('%Y-%m-%d %H:%M:%S')}]") # Added turn ID for context
+                    print(f"  Tú: {turn['user_prompt']}")
+                    print(f"  Gemini: {turn['ai_response']}")
+                    print("  ------------------------------------")
+                print("\n")
             else:
-                print("ID de conversación no válido. Intenta de nuevo.")
-        except ValueError:
-            print("Entrada no válida. Por favor ingresa un número.")
+                print("ID de sesión no válido o no encontrado en la lista actual. Intenta de nuevo.")
         except Exception as e:
-            print(f"Ocurrió un error: {e}")
+            print(f"Ocurrió un error al procesar la selección: {e}")
 
 def cargar_datos():
     from db.load_data import cargar_datos as cargar_datos_db


### PR DESCRIPTION
This commit introduces session management for conversation history.

Key changes:
- Added `session_id` to the `conversation_history` table to group related conversation turns.
- Updated database operations (`history_operations.py`) to generate, save, and retrieve conversation data based on these session IDs.
  - `save_conversation` now requires a `session_id`.
  - `get_all_conversations` now returns a list of unique sessions with their initial prompts.
  - `get_conversation_by_session_id` retrieves all turns for a specific session.
- Modified `main.py` to:
  - Generate and manage a `current_session_id` for active conversations.
  - Ensure new conversations start with a new session ID.
  - Update the history viewing feature to display conversations grouped by sessions.

This allows you to start new conversations, effectively ending the previous one from an active context, and view a more structured conversation history.